### PR TITLE
Clarify available params and improve examples in manifest

### DIFF
--- a/.github/workflows/gen-tiles.yml
+++ b/.github/workflows/gen-tiles.yml
@@ -78,7 +78,7 @@ jobs:
             if (!tileConfig) {
               throw new Error(`Tile configuration for '${TILE_NAME}' not found.`);
             }
-            const zoomLevel = (ACTION_TYPE == 'push') ? '5' : tileConfig.zoom_level;
+            const zoomLevel = (ACTION_TYPE == 'push') ? '5' : tileConfig.maxzoom;
             const commandParts = [
               `--style ${tileConfig.style}`,
               `-Z ${zoomLevel}`,
@@ -91,15 +91,6 @@ jobs:
             if (tileConfig.monthyear) commandParts.push(`--monthyear ${tileConfig.monthyear}`);
             if (tileConfig.mapbox_style) commandParts.push(`--mapboxstyle ${tileConfig.mapbox_style}`);
             if (tileConfig.minzoom) commandParts.push(`--minzoom ${tileConfig.minzoom}`);
-            if (tileConfig.maxzoom) commandParts.push(`--maxzoom ${tileConfig.maxzoom}`);
-            if (tileConfig.tile_format) commandParts.push(`--format ${tileConfig.tile_format}`);
-            if (tileConfig.scale) commandParts.push(`--scale ${tileConfig.scale}`);
-            if (tileConfig.tile_size) commandParts.push(`--size ${tileConfig.tile_size}`);
-            if (tileConfig.attribution) commandParts.push(`--attribution ${tileConfig.attribution}`);
-            if (tileConfig.logo) commandParts.push(`--logo ${tileConfig.logo}`);
-            if (tileConfig.center) commandParts.push(`--center ${tileConfig.center}`);
-            if (tileConfig.pixel_ratio) commandParts.push(`--pixel_ratio ${tileConfig.pixel_ratio}`);
-            if (tileConfig.language) commandParts.push(`--language ${tileConfig.language}`);
             const command = commandParts.join(' ');
             core.setOutput('command', command);
             if (useSSH) {
@@ -118,7 +109,7 @@ jobs:
       - name: Scrape tiles
         run: |
           docker run --rm -v ${{ github.workspace }}/outputs:/app/outputs communityfirst/mapgl-tile-renderer:main ${{ steps.load-manifest.outputs.command }}
-      - name: Copy mbtiles to EDT Cloud
+      - name: Copy mbtiles to cloud server
         if: ${{ steps.load-manifest.outputs.useSSH }}
         uses: appleboy/scp-action@v0.1.3
         with:
@@ -131,7 +122,7 @@ jobs:
           strip_components: 3
           timeout: 60s
           command_timeout: 30m
-      - name: Setting correct file persmissions
+      - name: Setting correct file permissions
         if: ${{ steps.load-manifest.outputs.useSSH }}
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Generate Tiles](https://github.com/digidem/map-template/actions/workflows/gen-tiles.yml/badge.svg?branch=main)](https://github.com/digidem/map-template/actions/workflows/gen-tiles.yml)
 
-This repository serves as a template for generating map tiles using GitHub Actions and [mapgl-tile-renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer). Once generated, the tiles are automatically uploaded to [Earth Defenders Toolkit Cloud](https://github.com/digidem/edt-cloud) for distribution to partners or for synchronization with Kakawa devices.
+This repository serves as a template for generating map tiles using GitHub Actions and [mapgl-tile-renderer](https://github.com/ConservationMetrics/mapgl-tile-renderer).
 
-To use this template repository effectively, customize the `manifest.json` file according to your project's requirements and configure secrets if using an online source that requires an API key, such as Planet or Mapbox, or want to copy final tiles to a remote cloud server.
+To use this template repository effectively, customize the `manifest.json` file according to your project's requirements and configure secrets if using an online source that requires an API key, such as Planet or Mapbox.
+
+You can configure this template to copy the generated tiles to a remote cloud server. In the example `manifest.json`, the tiles are automatically uploaded to [Earth Defenders Toolkit Cloud](https://github.com/digidem/edt-cloud) for distribution to partners or for synchronization with [Kakawa devices](http://docs.earthdefenderstoolkit.com/).
 
 ## Using This Template
 
@@ -36,24 +38,11 @@ The `manifest.json` file holds the configuration for the tile generation process
 - `name` (required): The base name for the generated `.mbtiles` file.
 - `style` (required): The map style to be used for tile generation. Specify 'self' for a self-provided style or use an online source such as 'mapbox', 'bing', 'planet', or 'esri'.
 - `bounds` (required): The geographical bounds for tile generation, formatted as `"minLongitude,minLatitude,maxLongitude,maxLatitude"`. Use a tool like [boundingbox](https://boundingbox.klokantech.com/) to obtain the values in CSV format.
-- `zoom_level` (required): The max zoom level at which the tiles will be generated. (e.g., `16`).
+- `maxzoom` (required): The maximum zoom level at which the tiles will be generated. (e.g., `16`).
+- `minzoom` (optional): The minimum zoom level for which the tiles will be generated. If not specified, the default minimum zoom level is used.
 - `monthyear` (optional): The month and year for which the Planet tiles are generated, formatted as `YYYY-MM`. This is required if using 'planet' as the online source for tile generation.
-
 - `mapbox_style` (optional): The Mapbox style in the format `<yourusername>/<styleid>`. This is required if using 'mapbox' as the online source for tile generation.
 - `apiKeySecret` (optional): The name of the secret where the API key is stored. Defaults to `API_KEY` if not specified.
-- `minzoom` (optional): The minimum zoom level for which the tiles will be generated. If not specified, the default minimum zoom level is used.
-- `maxzoom` (optional): The maximum zoom level for which the tiles will be generated. This should not exceed the `zoom_level` specified.
-- `tile_format` (optional): The format of the tiles to generate (e.g., "png", "jpg"). Defaults to the format specified by the tile rendering service.
-- `scale` (optional): The scale factor for the tiles, which is useful for generating @2x tiles for retina displays.
-- `tile_size` (optional): The size of the tiles in pixels (e.g., "256", "512"). Defaults to the size specified by the tile rendering service.
-- `attribution` (optional): The attribution to be included in the tiles' metadata. This is important for copyright and licensing information.
-- `logo` (optional): The URL to a logo image to be included in the tiles' metadata. This can be used for branding purposes.
-- `center` (optional): The center of the map in "longitude,latitude,zoom" format. This is used to set the initial view when the map is loaded.
-- `pixel_ratio` (optional): The pixel ratio to consider for retina displays. This is used in conjunction with the `scale` option.
-- `language` (optional): The language to be used for map labels. This is important for localization and providing maps in the user's preferred language.
-
-
-Example options for `manifest.json`:
 
 ## Workflow Overview
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,64 +4,58 @@
             "name": "planet", // Base name for the generated .mbtiles file
             "style": "planet", // Map style to be used for tile generation
             "monthyear": "2023-12", // Month and year for which the tiles are generated, in YYYY-MM format
-            "bounds": "-54.28772,3.11460,-54.03630,3.35025", // Geographical bounds for the tile generation in "minLongitude,minLatitude,maxLongitude,maxLatitude" format
-            "zoom_level": "16" // Zoom level for which the tiles will be generated
+            "bounds": "-60,0,-59,1", // Geographical bounds for the tile generation in "minLongitude,minLatitude,maxLongitude,maxLatitude" format
+            "maxzoom": "16", // Maximum zoom level for which the tiles will be generated
+            // "minzoom": "", // Minimum zoom level for which the tiles will be generated
             // "mapbox_style": "", // Mapbox style in the format <yourusername>/<styleid>
             // "apiKeySecret": "", // Api key secret name, defaults to API_KEY
-            // "minzoom": "", // Minimum zoom level for which the tiles will be generated
-            // "maxzoom": "", // Maximum zoom level for which the tiles will be generated
-            // "tile_format": "", // Format of the tiles to generate (e.g., "png", "jpg")
-            // "scale": "", // Scale factor for the tiles (e.g., "1", "2" for @2x tiles)
-            // "tile_size": "", // Size of the tiles in pixels (e.g., "256", "512")
-            // "attribution": "", // Attribution to be included in the tiles metadata
-            // "logo": "", // URL to a logo image to be included in the tiles metadata
-            // "bounds": "", // Overriding the bounds for the tile generation in "minLongitude,minLatitude,maxLongitude,maxLatitude" format
-            // "center": "", // Center of the map in "longitude,latitude,zoom" format
-            // "pixel_ratio": "", // Pixel ratio to consider for retina displays
-            // "language": "", // Language to be used for map labels
         },
         {
             "name": "mapbox",
             "style": "mapbox",
-            "bounds": "-54.28772,3.11460,-54.03630,3.35025",
-            "zoom_level": "16",
-            "mapbox_style": "luandro/clryy7mbc018u01p1a68026nl",
+            "bounds": "-60,0,-59,1",
+            "maxzoom": "16",
+            "mapbox_style": "mapbox/satellite-v9",
             "apiKeySecret": "MAPBOX_API_KEY"
         },
         {
             "name": "bing",
             "style": "bing",
-            "bounds": "-54.28772,3.11460,-54.03630,3.35025",
-            "zoom_level": "10"
+            "bounds": "-60,0,-59,1",
+            "maxzoom": "10"
         },
         {
             "name": "esri",
             "style": "esri",
-            "bounds": "-54.28772,3.11460,-54.03630,3.35025",
-            "zoom_level": "10",
+            "bounds": "-60,0,-59,1",
+            "maxzoom": "10",
             "overlay": {
                 "type": "FeatureCollection",
-                "name": "alert",
+                "name": "AOI",
                 "features": [
                     {
                         "geometry": {
                             "coordinates": [
                                 [
                                     [
-                                        -54.25348208981326,
-                                        3.140689896338671
+                                        -59.75,
+                                        0.25
                                     ],
                                     [
-                                        -54.25348208981326,
-                                        3.140600064810259
+                                        -59.25,
+                                        0.25
                                     ],
                                     [
-                                        -54.253841415926914,
-                                        3.140600064810259
+                                        -59.25,
+                                        0.75
                                     ],
                                     [
-                                        -54.25348208981326,
-                                        3.140689896338671
+                                        -59.75,
+                                        0.75
+                                    ],
+                                    [
+                                        -59.75,
+                                        0.25
                                     ]
                                 ]
                             ],


### PR DESCRIPTION
This PR:

* Culls the list of `tileConfig` parameters to be only those that are used by mapgl-tile-renderer.
* Generalizes the description for using `useSSH` (with EDT Cloud as an example).
* Makes some small typo fixes here and there.
* Changes the `manifest.json` tile example bounds to be in a more "general" location (e.g. not a partner territory).